### PR TITLE
Prevent different git references from being cached under the same folder

### DIFF
--- a/lib/pkg.js
+++ b/lib/pkg.js
@@ -21,7 +21,10 @@ function NapaPkg(url, name, opts) {
   this.url = url
   this.name = name
   this.installTo = path.join(this.cwd, 'node_modules', this.name)
-  this.cacheTo = cache(tmp, this.url)
+  this.cacheTo = cache(tmp, this.url + ( !(/\.zip$/.test(this.url)) && this.ref
+                                       ? '#' + this.ref
+                                       : ''
+                                       ))
   this._napaResolvedKey = '_napaResolved'
 
   Object.defineProperty(self, 'installed', {

--- a/lib/pkg.js
+++ b/lib/pkg.js
@@ -9,6 +9,7 @@ var tmp = path.join(require('os').tmpdir(), 'cache')
 var mkdirp = require('mkdirp')
 var pack = require('tar-pack').pack
 var unpack = require('tar-pack').unpack
+var npm = require('npm')
 
 function NapaPkg(url, name, opts) {
   if (!(this instanceof NapaPkg)) return new NapaPkg(url, name, opts)
@@ -42,9 +43,6 @@ module.exports = NapaPkg
 NapaPkg.prototype.install = function(done) {
   var self = this, cbCalled = false
   done = done || function() {}
-
-  // Do nothing if already installed
-  if (self.installed) return done()
 
   function cb(err) {
     if (err) return done(err.message)
@@ -98,23 +96,35 @@ NapaPkg.prototype.install = function(done) {
     }
   }
 
-  // is this a git repo url?
-  var gitUrls = ['git+', 'git://']
+  function install() {
+    // is this a git repo url?
+    var gitUrls = ['git+', 'git://']
 
-  // Determine which type of install we would like
-  rimraf(self.installTo, function(err) {
-    if (err) log.error(err.message)
-    if (fs.existsSync(self.cacheTo)) {
-      return cacheInstall()
-    } else if (gitUrls.indexOf(self.url.slice(0, 4)) !== -1) {
-      return gitInstall()
-    } else {
-      if (self.url.indexOf('github.com') !== -1 && self.url.indexOf('/archive/') === -1) {
+    // Determine which type of install we would like
+    rimraf(self.installTo, function(err) {
+      if (err) log.error(err.message)
+      if (fs.existsSync(self.cacheTo)) {
+        return cacheInstall()
+      } else if (gitUrls.indexOf(self.url.slice(0, 4)) !== -1) {
         return gitInstall()
+      } else {
+        if (self.url.indexOf('github.com') !== -1 && self.url.indexOf('/archive/') === -1) {
+          return gitInstall()
+        }
+        return downloadInstall()
       }
-      return downloadInstall()
-    }
-  })
+    })
+  }
+
+  // If already installed, uninstall first
+  if (self.installed) return npm.load({}, function(err) {
+    if (err) return cb(err);
+    npm.commands.uninstall(self.name, function(err) {
+      if (err) return cb(err);
+      install();
+    });
+  });
+  else install();
 }
 
 // Caches a locally installed package

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "download": ">=3.0.1 <3.1.0-0",
     "mkdirp": ">=0.5.0 <0.6.0-0",
-    "npm-cache-filename": ">=1.0.1 <1.1.0-0",
+    "npm-cache-filename": "tomekwi/npm-cache-filename",
     "npmlog": ">=0.1.1 <0.2.0-0",
     "rimraf": ">=2.2.8 <2.3.0-0",
     "tar-pack": ">=2.0.0 <2.1.0-0"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "npm-cache-filename": "tomekwi/npm-cache-filename",
     "npmlog": ">=0.1.1 <0.2.0-0",
     "rimraf": ">=2.2.8 <2.3.0-0",
-    "tar-pack": ">=2.0.0 <2.1.0-0"
+    "tar-pack": ">=2.0.0 <2.1.0-0",
+    "npm": ">=2.1.9 <2.2.0-0"
   },
   "devDependencies": {
     "tape": ">=3.0.0 <3.1.0-0"


### PR DESCRIPTION
Hello,

When installing packages from _git://…#tag_ urls, you can't update the the package without manually clearing the cache – the cached path doesn't take the reference into account.

I've created [a pull request for npm-cache-filename](https://github.com/npm/npm-cache-filename/pull/1) as well.

Cheers