### PR TITLE
Make the github repo check more explicit

### DIFF
--- a/lib/pkg.js
+++ b/lib/pkg.js
@@ -97,6 +97,7 @@ NapaPkg.prototype.install = function(done) {
 
   // is this a git repo url?
   var gitUrls = ['git+', 'git://']
+  var githubDownloadUrls = /github\.com(?:\/[^\/]+){2}($|#)/
 
   // Determine which type of install we would like
   rimraf(self.installTo, function(err) {
@@ -106,7 +107,7 @@ NapaPkg.prototype.install = function(done) {
     } else if (gitUrls.indexOf(self.url.slice(0, 4)) !== -1) {
       return gitInstall()
     } else {
-      if (self.url.indexOf('github.com') !== -1 && self.url.indexOf('/archive/') === -1) {
+      if (githubDownloadUrls.test(self.url)) {
         return gitInstall()
       }
       return downloadInstall()

--- a/lib/pkg.js
+++ b/lib/pkg.js
@@ -97,7 +97,7 @@ NapaPkg.prototype.install = function(done) {
 
   // is this a git repo url?
   var gitUrls = ['git+', 'git://']
-  var githubDownloadUrls = /github\.com(?:\/[^\/]+){2}($|#)/
+  var githubRepoUrls = /github\.com(?:\/[^\/]+){2}($|#)/
 
   // Determine which type of install we would like
   rimraf(self.installTo, function(err) {
@@ -107,7 +107,7 @@ NapaPkg.prototype.install = function(done) {
     } else if (gitUrls.indexOf(self.url.slice(0, 4)) !== -1) {
       return gitInstall()
     } else {
-      if (githubDownloadUrls.test(self.url)) {
+      if (githubRepoUrls.test(self.url)) {
         return gitInstall()
       }
       return downloadInstall()

--- a/test.js
+++ b/test.js
@@ -27,7 +27,7 @@ test('args', function(t) {
 })
 
 test('cmds', function(t) {
-  t.plan(7)
+  t.plan(8)
   var testPath = path.resolve('node_modules', 'test')
   var pkg = null
 
@@ -61,6 +61,9 @@ test('cmds', function(t) {
   })
   assertPkg('https://github.com/angular/angular.js/archive/master.zip', 'angular', function(result) {
     t.deepEqual(result, ['download', 'https://github.com/angular/angular.js/archive/master.zip', path.resolve('node_modules', 'angular')])
+  })
+  assertPkg('https://github.com/yahoo/pure/releases/download/v0.5.0/pure-0.5.0.tar.gz', 'pure', function(result) {
+    t.deepEqual(result, ['download', 'https://github.com/yahoo/pure/releases/download/v0.5.0/pure-0.5.0.tar.gz', path.resolve('node_modules', 'pure')])
   })
 })
 


### PR DESCRIPTION
`github.com/.../...` and `github.com/.../...#...` are repositories. The rest are normal downloads.

This fixes #33.