### PR TITLE
Allow log level to be configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,12 +88,14 @@ The application currently supports the following configuration options under a `
 
 * "cache" - Set to *false* to completely disable package caching.
 * "cache-path" - Override default path to a specific location(relative to the current working directory)
+* "log-level" - Set the log level (default is 'info', may also be 'silent', 'error', 'warn', 'verbose', or 'silly').
 
 ```json
 {
   "napa-config": {
     "cache": false,
-    "cache-path": "../.napa-cache"
+    "cache-path": "../.napa-cache",
+    "log-level": "error"
   }
 }
 ```

--- a/lib/pkg.js
+++ b/lib/pkg.js
@@ -18,6 +18,7 @@ function NapaPkg (url, name, opts) {
   opts = opts || {}
   this.cwd = opts.cwd || process.cwd()
   this.log = opts.log || log
+  if (opts['log-level']) this.log.level = opts['log-level']
   this._mock = opts._mock
   this.ref = opts.ref
   this.url = url


### PR DESCRIPTION
Thanks for the useful project.  I've found the default "info" logging a bit verbose, particularly when you have commit-ish git URLs.  E.g.

```
$ napa

info git git+ssh://git@github.com/user/repo-name.git into repo-name
info Note: checking out '3440a201889396eed3a7906a804742d6200bbe37'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by performing another checkout.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -b with the checkout command again. Example:

  git checkout -b <new-branch-name>

 
info HEAD is now at 3440a20... Merge pull request #123 from user/branch

...
```

I'm hoping you'll consider supporting this `log-level` option.
