### PR TITLE
 Added options to just git clone a url and leave .git alone if requested

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,21 @@ Now it will install to `node_modules/adifferentname`.
 }
 ```
 
+### Looking to just `git clone` a tagged release/a branch/a specific commit on github or git url?
+
+```json
+{
+  "scripts": {
+    "install": "napa"
+  },
+  "napa": {
+    "foo": "username/repo@v1.2.3",
+    "bar": "username/bar@some-branch",
+    "baz": "username/baz@347259472813400c7a982690acaa516292a8be40"
+  }
+}
+```
+
 ### Additional configuration
 
 The application currently supports the following configuration options under a `napa-config` property in `package.json`.
@@ -91,13 +106,15 @@ Option name | Default value | Desctiption
 `cache` | `true` | Set to `false` to completely disable package caching
 `cache-path` | [`'<OS temp>/cache'`](https://github.com/shama/napa/blob/master/lib/pkg.js#L8) | Override default path to a specific location<br>(relative to the current working directory)
 `log-level` | `'info'`  | Set the log level: `'silent'`/`'error'`/`'warn'`/`'verbose'`/`'silly'`
+`leave-git` | `false` | Set to `true` to leave the `.git` folder after cloning
 
 ```json
 {
   "napa-config": {
     "cache": false,
     "cache-path": "../.napa-cache",
-    "log-level": "error"
+    "log-level": "error",
+    "leave-git": false
   }
 }
 ```

--- a/cli.js
+++ b/cli.js
@@ -85,6 +85,15 @@ napa.url = function (url) {
     }
   }
 
+  if (url.indexOf('@') !== -1) {
+    if (url.indexOf('://') === -1) {
+      var ss = url.split('@')
+      url = 'https://github.com/' + ss[0]
+    } else {
+      url = url.replace(/@.*?$/, '')
+    }
+  }
+
   if (url.slice(0, 1) === '/') {
     url = url.slice(1)
   }
@@ -122,5 +131,5 @@ napa._loadFromPkg = function (property, defaults) {
 }
 
 napa.getref = function (url) {
-  return url.replace(/^[^#]*#?/, '')
+  return url.replace(/^[^#]*#?/, '') || url.replace(/^[^@]*@?/, '')
 }

--- a/lib/pkg.js
+++ b/lib/pkg.js
@@ -33,6 +33,7 @@ function NapaPkg (url, name, opts) {
   )
   this._napaResolvedKey = '_napaResolved'
   this.saveToPkgJson = opts.save
+  this.leaveGit = opts['leave-git'] || false
 
   Object.defineProperty(self, 'installed', {
     get: function () {
@@ -92,11 +93,14 @@ NapaPkg.prototype.install = function (done) {
         var checkout
         if (code) return cb(code, signal)
         if (self.ref) {
-          checkout = spawn('git', ['checkout', self.ref], {cwd: self.installTo})
+          checkout = spawn('git', ['checkout', '-f', self.ref], {cwd: self.installTo})
           checkout.stderr.on('data', log.info)
           checkout.on('close', function () {
-            rimraf(path.resolve(self.installTo, '.git'), cb)
+            if (self.leaveGit) cb()
+            else rimraf(path.resolve(self.installTo, '.git'), cb)
           })
+        } else if (self.leaveGit) {
+          cb()
         } else {
           rimraf(path.resolve(self.installTo, '.git'), cb)
         }


### PR DESCRIPTION
This PR allows napa to:

- Just perform a simple `git clone` instead of downloading a URL
- Leave the `.git` folder alone if requested in the config.

Sometimes it's required to `git clone` a SHA1. Downloading its archive from Github is not useful. This PR introduces `@` in specifying the tag/branch/release. When `@` is given, the URL is treated as-is.

`.git` folder is crucial for some repos that perform hooks and are set up with [patch-package](https://github.com/ds300/patch-package)

Also, `git checkout` now forces to do a checkout. Some repos do post-clone hooks that leaves the repo unclean. In that state, doing a simple unforced `git checkout` fails.