### PR TITLE
Add installTo option

### DIFF
--- a/lib/pkg.js
+++ b/lib/pkg.js
@@ -23,7 +23,7 @@ function NapaPkg (url, name, opts) {
   this.ref = opts.ref
   this.url = url
   this.name = name
-  this.installTo = path.join(this.cwd, 'node_modules', this.name)
+  this.installTo = opts.installTo ? path.join(this.cwd, opts.installTo) : path.join(this.cwd, 'node_modules', this.name)
   this.useCache = (typeof opts.cache === 'undefined') || opts.cache !== false
   this.cacheTo = cache(
     typeof opts['cache-path'] !== 'string'


### PR DESCRIPTION
NPM likes to delete extra directories whenever another package is installed. This means that after running `npm install x` you have to run `npm install` to get the napa packages back again. Adding an installTo option can allow a developer to install napa packages to a different directory outside of node_modules ('vendor' perhaps) and prevent npm from deleting the napa packages.