### PR TITLE
Adding support for #72 single file download

### DIFF
--- a/lib/pkg.js
+++ b/lib/pkg.js
@@ -31,6 +31,7 @@ function NapaPkg (url, name, opts) {
       : path.resolve(this.cwd, opts['cache-path']),
     this.url
   )
+  this.strictDecompress = !!opts.strictDecompress
   this._napaResolvedKey = '_napaResolved'
   this.saveToPkgJson = opts.save
 
@@ -109,7 +110,12 @@ NapaPkg.prototype.install = function (done) {
       self._mock(['download', self.url, self.installTo])
     } else {
       self.log.info('download', '%s into %s', self.url, self.name)
-      download(self.url, self.installTo, { extract: true, strip: 1 })
+      var extractOptions = { extract: true, strip: 1 }
+      if (self.strictDecompress) {
+        // decompress module options
+        extractOptions = /(\.zip$)|(\.tar$)|(\.tar\.(gz|bz2?|xz)$)/.test(self.url) ? extractOptions : {}
+      }
+      download(self.url, self.installTo, extractOptions)
         .then(function () { cb() }, cb)
     }
   }


### PR DESCRIPTION
Hopefully a simple option works best for #72. Instead of blindly passing decompress options, it can be more specific by testing the url for supported extensions (if enabled). It's not perfect but this avoids having to use libmagic or some native dependency to actually verify the file type.